### PR TITLE
[TS-5429] Ensure name double quote, but not more

### DIFF
--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -754,15 +754,10 @@ encode_header_value(H, Value) when H =:= <<"To">>; H =:= <<"Cc">>; H =:= <<"Bcc"
 	{ok, Addresses} = smtp_util:parse_rfc822_addresses(Value),
 	{Names, Emails} = lists:unzip(Addresses),
 	NewNames = lists:map(fun rfc2047_utf8_encode/1, Names),
-  Quoted_Names = [quote_name(H, Name) || Name <- NewNames],
-	smtp_util:combine_rfc822_addresses(lists:zip(Quoted_Names, Emails));
+	smtp_util:combine_rfc822_addresses(lists:zip(NewNames, Emails));
 
 encode_header_value(_, Value) ->
 	rfc2047_utf8_encode(Value).
-
-quote_name(<<"From">>, Name) ->
-  "\"" ++ Name ++ "\"";
-quote_name(_, Name) -> Name.
 
 encode_component(_Type, _SubType, Headers, Params, Body) ->
 	if

--- a/src/smtp_util.erl
+++ b/src/smtp_util.erl
@@ -136,7 +136,8 @@ combine_rfc822_addresses([{Name, Email}|Rest], Acc) ->
 
 opt_quoted(N)  ->
 	case re:run(N, "\"") of
-		nomatch -> N;
+		nomatch ->
+			[$", N, $"];
 		{match, _} ->
 			[$", re:replace(N, "\"", "\\\\\"", [global]), $"]
 	end.


### PR DESCRIPTION
We always send the from without double quotes in. This adds the double quotes, but not more like here: https://github.com/tigertext/gen_smtp/pull/13/files#diff-cc30915952cc1905c073c77bacc6e6ddR140