### PR TITLE
TS-7170 Fix email consumer

### DIFF
--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -984,7 +984,7 @@ rfc2047_utf8_encode([C|T], Acc, WordLen, Char) when C > 192 andalso C =< 247 ->
     UTFBytes = utf_char_bytes(C),
     {Rest, ExtraUTFBytes} = encode_extra_utf_bytes(UTFBytes-1, T),
     rfc2047_utf8_encode(Rest, Char ++ Acc, WordLen+length(Char), ExtraUTFBytes ++ encode_byte(C));
-rfc2047_utf8_encode([C|T], Acc, WordLen, Char) when C =:= 10 ->
+rfc2047_utf8_encode([C|T], Acc, WordLen, Char) when C =:= $\n ->
 	rfc2047_utf8_encode(T, Char ++ Acc, WordLen+length(Char), encode_byte(C)).
 
 is_ascii_printable([]) -> 'true';

--- a/src/mimemail.erl
+++ b/src/mimemail.erl
@@ -983,7 +983,9 @@ rfc2047_utf8_encode([C|T], Acc, WordLen, Char) when C >= 32 andalso C < 127 ->
 rfc2047_utf8_encode([C|T], Acc, WordLen, Char) when C > 192 andalso C =< 247 ->
     UTFBytes = utf_char_bytes(C),
     {Rest, ExtraUTFBytes} = encode_extra_utf_bytes(UTFBytes-1, T),
-    rfc2047_utf8_encode(Rest, Char ++ Acc, WordLen+length(Char), ExtraUTFBytes ++ encode_byte(C)).
+    rfc2047_utf8_encode(Rest, Char ++ Acc, WordLen+length(Char), ExtraUTFBytes ++ encode_byte(C));
+rfc2047_utf8_encode([C|T], Acc, WordLen, Char) when C =:= 10 ->
+	rfc2047_utf8_encode(T, Char ++ Acc, WordLen+length(Char), encode_byte(C)).
 
 is_ascii_printable([]) -> 'true';
 is_ascii_printable([H|T]) when H >= 32 andalso H =< 126 ->

--- a/src/smtp_socket.erl
+++ b/src/smtp_socket.erl
@@ -40,9 +40,6 @@
                               {keepalive, true},
                               {keyfile, "server.key"},
                               {packet, line},
-							  {server_renegotiate, true},
-                              {versions, get_tls_versions()},
-                              {ciphers, get_ciphers()}, 
                               {reuse_sessions, false},
                               {reuseaddr, true},
                               {ssl_imp, new}]).
@@ -285,48 +282,7 @@ type(_Socket) ->
 %%%-----------------------------------------------------------------
 %%% Internal functions (OS_Mon configuration)
 %%%-----------------------------------------------------------------
-get_tls_versions() ->
-    application:get_env(email_gateway, tls_versions, ['tlsv1', 'tlsv1.1', 'tlsv1.2' ]).
 
-get_ciphers() ->
-	application:get_env(email_gateway, ciphers, [
-          {ecdhe_ecdsa,aes_256_cbc,sha384},
-          {ecdhe_rsa,aes_256_cbc,sha384},
-          {ecdh_ecdsa,aes_256_cbc,sha384},
-          {ecdh_rsa,aes_256_cbc,sha384},
-          {dhe_rsa,aes_256_cbc,sha256},
-          {dhe_dss,aes_256_cbc,sha256},
-          {rsa,aes_256_cbc,sha256},
-          {ecdhe_ecdsa,aes_128_cbc,sha256},
-          {ecdhe_rsa,aes_128_cbc,sha256},
-          {ecdh_ecdsa,aes_128_cbc,sha256},
-          {ecdh_rsa,aes_128_cbc,sha256},
-          {dhe_rsa,aes_128_cbc,sha256},
-          {dhe_dss,aes_128_cbc,sha256},
-          {rsa,aes_128_cbc,sha256},
-          {ecdhe_ecdsa,aes_256_cbc,sha},
-          {ecdhe_rsa,aes_256_cbc,sha},
-          {dhe_rsa,aes_256_cbc,sha},
-          {dhe_dss,aes_256_cbc,sha},
-          {ecdh_ecdsa,aes_256_cbc,sha},
-          {ecdh_rsa,aes_256_cbc,sha},
-          {rsa,aes_256_cbc,sha},
-          {ecdhe_ecdsa,'3des_ede_cbc',sha},
-          {ecdhe_rsa,'3des_ede_cbc',sha},
-          {dhe_rsa,'3des_ede_cbc',sha},
-          {dhe_dss,'3des_ede_cbc',sha},
-          {ecdh_ecdsa,'3des_ede_cbc',sha},
-          {ecdh_rsa,'3des_ede_cbc',sha},
-          {rsa,'3des_ede_cbc',sha},
-          {ecdhe_ecdsa,aes_128_cbc,sha},
-          {ecdhe_rsa,aes_128_cbc,sha},
-          {dhe_rsa,aes_128_cbc,sha},
-          {dhe_dss,aes_128_cbc,sha},
-          {ecdh_ecdsa,aes_128_cbc,sha},
-          {ecdh_rsa,aes_128_cbc,sha},
-          {rsa,aes_128_cbc,sha}]
-          ).
-		
 tcp_listen_options([Format|Options]) when Format =:= list; Format =:= binary ->
 	tcp_listen_options(Options, Format);
 tcp_listen_options(Options) ->


### PR DESCRIPTION
Two things in this PR:
1. Allow "\n" in headers so this won't crash:
```erlang
mimemail:rfc2047_utf8_encode("Encrypted Message from &#60;script&#62; at Santa Monica Memorial Hospital\n")
```
2. Revert changes made by George. All test cases can pass.